### PR TITLE
Modify char assigner route signature

### DIFF
--- a/oot3dhdtextgenerator/apps/char_assigner/routes.py
+++ b/oot3dhdtextgenerator/apps/char_assigner/routes.py
@@ -1,16 +1,20 @@
 #  Copyright 2020-2025 Karl T Debiec. All rights reserved. This software may be modified
 #  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Routes for the character assignment web application."""
+
 from __future__ import annotations
 
 from flask import render_template, request
 
 
 def route(char_assigner):
+    """Register routes for the Flask application."""
+
     @char_assigner.app.route("/", methods=["GET"])
     def index():
         return render_template("index.html", characters=char_assigner.characters)
 
-    @char_assigner.app.route("/characters/<int:id>", methods=["PUT"])
+    @char_assigner.app.route("/characters/<int:character_id>", methods=["PUT"])
     def update_character(character_id):
         assignment = request.form["assignment"]
         if assignment == "":


### PR DESCRIPTION
## Summary
- add module docstring for `routes`
- register route with `character_id` parameter

## Testing
- `uv run ruff format oot3dhdtextgenerator/apps/char_assigner/routes.py`
- `uv run ruff check --fix oot3dhdtextgenerator/apps/char_assigner/routes.py`
- `uv run pyright oot3dhdtextgenerator/apps/char_assigner/routes.py`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6878e45cad988325ab1358e248f12dba