### PR TITLE
Add recreatable repr methods

### DIFF
--- a/oot3dhdtextgenerator/apps/char_assigner/character.py
+++ b/oot3dhdtextgenerator/apps/char_assigner/character.py
@@ -38,6 +38,14 @@ class Character:
         self._image = None
         self.predictions = predictions
 
+    def __repr__(self) -> str:
+        """Representation."""
+        array_repr = f"np.array({self.array.tolist()!r}, dtype=np.uint8)"
+        return (
+            f"{self.__class__.__name__}("
+            f"{self.id!r}, {array_repr}, {self.assignment!r}, {self.predictions!r})"
+        )
+
     @property
     def image(self) -> str:
         """Base64 encoded PNG representation of the character.

--- a/oot3dhdtextgenerator/core/learning_dataset.py
+++ b/oot3dhdtextgenerator/core/learning_dataset.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 import h5py
 import numpy as np
@@ -54,15 +55,17 @@ class LearningDataset(VisionDataset):
             transform: Transform to apply to images
             target_transform: Transform to apply to targets
         """
-        infile = validate_input_file(infile)
+        self.infile = validate_input_file(infile)
+        self.transform = transform
+        self.target_transform = target_transform
         super().__init__(
-            str(infile.parent),
+            str(self.infile.parent),
             transform=transform,
             target_transform=target_transform,
         )
-        self.images, self.specifications = self.load_hdf5(infile)
+        self.images, self.specifications = self.load_hdf5(self.infile)
 
-    def __getitem__(self, index: int) -> tuple[np.ndarray, int]:
+    def __getitem__(self, index: int) -> tuple[Any, int]:
         """Get image and target at index."""
         image = Image.fromarray(self.images[index])
         target = character_to_index(self.specifications[index]["character"])
@@ -77,6 +80,14 @@ class LearningDataset(VisionDataset):
     def __len__(self) -> int:
         """Number of images in the dataset."""
         return len(self.images)
+
+    def __repr__(self) -> str:
+        """Representation."""
+        return (
+            f"{self.__class__.__name__}("
+            f"Path({self.infile!r}), transform={self.transform!r}, "
+            f"target_transform={self.target_transform!r})"
+        )
 
     @classmethod
     def decode_specification(cls, encoded_specifications: np.ndarray) -> np.ndarray:

--- a/oot3dhdtextgenerator/core/model.py
+++ b/oot3dhdtextgenerator/core/model.py
@@ -19,6 +19,7 @@ class Model(Module):
             n_chars: Number of characters in dataset
         """
         super().__init__()
+        self.n_chars = n_chars
 
         self.conv1 = Conv2d(1, 64, kernel_size=2, stride=1, padding="same")
         self.conv2 = Conv2d(64, 128, kernel_size=2, stride=1, padding="same")
@@ -31,6 +32,10 @@ class Model(Module):
         summary(self.maxpool, input_size=(1, 128, 8, 8))
         summary(Flatten(), input_size=(1, 128, 4, 4))
         summary(self.fc1, input_size=(1, 128 * 4 * 4))
+
+    def __repr__(self) -> str:
+        """Representation."""
+        return f"{self.__class__.__name__}({self.n_chars!r})"
 
     def forward(self, x: Tensor) -> Tensor:
         """Forward pass of the model.

--- a/oot3dhdtextgenerator/utilities/learning_dataset_generator.py
+++ b/oot3dhdtextgenerator/utilities/learning_dataset_generator.py
@@ -21,6 +21,10 @@ from oot3dhdtextgenerator.data import hanzi_frequency
 class LearningDatasetGenerator(Utility):
     """Learning dataset generator."""
 
+    def __repr__(self) -> str:
+        """Representation."""
+        return f"{self.__class__.__name__}()"
+
     @classmethod
     def generate_character_images(
         cls, n_chars: int = 10
@@ -119,7 +123,7 @@ class LearningDatasetGenerator(Utility):
         info(f"Saved {test_images.shape[0]} character images to {test_outfile}")
 
     @staticmethod
-    def generate_character_image(
+    def generate_character_image(  # noqa: PLR0913
         char: str,
         *,
         font: str = r"C:\Windows\Fonts\simhei.ttf",


### PR DESCRIPTION
## Summary
- implement recreatable `__repr__` methods on core and utility classes
- persist initialization parameters for recreation
- fix typing issues flagged by pyright
- minor improvements for dataset generation

## Testing
- `uv run ruff format oot3dhdtextgenerator/apps/char_assigner/char_assigner.py oot3dhdtextgenerator/apps/char_assigner/character.py oot3dhdtextgenerator/core/assignment_dataset.py oot3dhdtextgenerator/core/learning_dataset.py oot3dhdtextgenerator/core/model.py oot3dhdtextgenerator/utilities/learning_dataset_generator.py oot3dhdtextgenerator/utilities/model_trainer.py`
- `uv run ruff check --fix oot3dhdtextgenerator/apps/char_assigner/char_assigner.py oot3dhdtextgenerator/apps/char_assigner/character.py oot3dhdtextgenerator/core/assignment_dataset.py oot3dhdtextgenerator/core/learning_dataset.py oot3dhdtextgenerator/core/model.py oot3dhdtextgenerator/utilities/learning_dataset_generator.py oot3dhdtextgenerator/utilities/model_trainer.py`
- `uv run pyright oot3dhdtextgenerator/apps/char_assigner/char_assigner.py oot3dhdtextgenerator/apps/char_assigner/character.py oot3dhdtextgenerator/core/assignment_dataset.py oot3dhdtextgenerator/core/learning_dataset.py oot3dhdtextgenerator/core/model.py oot3dhdtextgenerator/utilities/learning_dataset_generator.py oot3dhdtextgenerator/utilities/model_trainer.py`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791b57c8988325b2908bd82853c568