### PR TITLE
Rename filesystem path variables

### DIFF
--- a/oot3dhdtextgenerator/apps/char_assigner/char_assigner.py
+++ b/oot3dhdtextgenerator/apps/char_assigner/char_assigner.py
@@ -19,11 +19,13 @@ from oot3dhdtextgenerator.core import AssignmentDataset, Model
 
 
 class CharAssigner:
+    """Assign characters using a trained model."""
+
     def __init__(
         self,
         n_chars: int,
-        assignment_file: Path,
-        model_infile: Path,
+        assignment_path: Path,
+        model_in_path: Path,
         *,
         cuda_enabled: bool = True,
         mps_enabled: bool = True,
@@ -32,8 +34,8 @@ class CharAssigner:
 
         Arguments:
             n_chars: Number of characters included in model
-            assignment_file: Assignment HDF5 file
-            model_infile: Model pth file
+            assignment_path: Assignment HDF5 file
+            model_in_path: Model pth file
             cuda_enabled: Whether to use CUDA
             mps_enabled: Whether to use macOS GPU
         """
@@ -47,8 +49,8 @@ class CharAssigner:
             device = torch.device("cpu")
 
         # Load assignment data
-        self.assignment_file = validate_input_file(assignment_file)
-        self.dataset = AssignmentDataset(self.assignment_file)
+        self.assignment_path = validate_input_file(assignment_path)
+        self.dataset = AssignmentDataset(self.assignment_path)
         loader_kwargs = {"batch_size": len(self.dataset), "shuffle": False}
         if cuda_enabled:
             loader_kwargs.update({"num_workers": 1, "pin_memory": True})
@@ -57,7 +59,7 @@ class CharAssigner:
 
         # Load model
         model = Model(n_chars)
-        model.load_state_dict(torch.load(model_infile))
+        model.load_state_dict(torch.load(model_in_path))
         model.eval()
         model = model.to(device)
 
@@ -73,6 +75,7 @@ class CharAssigner:
         route(self)
 
     def run(self, **kwargs: Any) -> None:
+        """Run the Flask application."""
         self.app.run(**kwargs)
 
     @staticmethod

--- a/oot3dhdtextgenerator/apps/char_assigner/routes.py
+++ b/oot3dhdtextgenerator/apps/char_assigner/routes.py
@@ -26,7 +26,7 @@ def route(char_assigner):
             char_assigner.dataset.save_hdf5(
                 char_assigner.dataset.assigned_char_bytes,
                 char_assigner.dataset.unassigned_char_bytes,
-                char_assigner.assignment_file,
+                char_assigner.assignment_path,
             )
 
         return render_template("character.html", character=character)

--- a/oot3dhdtextgenerator/cli/char_assigner_cli.py
+++ b/oot3dhdtextgenerator/cli/char_assigner_cli.py
@@ -47,12 +47,14 @@ class CharAssignerCli(CommandLineInterface):
         )
         arg_groups["input arguments"].add_argument(
             "--assignment-file",
+            dest="assignment_path",
             type=input_file_arg(),
             default="assignment.h5",
             help="assignment input and output file (default: %(default)s)",
         )
         arg_groups["input arguments"].add_argument(
             "--model-infile",
+            dest="model_in_path",
             type=input_file_arg(must_exist=False),
             default="model_{n_chars}.pth",
             help="model input file (default: %(default)s)",
@@ -77,8 +79,8 @@ class CharAssignerCli(CommandLineInterface):
     @classmethod
     def main_internal(cls, **kwargs: Any) -> None:
         """Execute with provided keyword arguments."""
-        kwargs["model_infile"] = validate_input_file(
-            str(kwargs["model_infile"]).format(**kwargs)
+        kwargs["model_in_path"] = validate_input_file(
+            str(kwargs["model_in_path"]).format(**kwargs)
         )
         char_assigner = CharAssigner(**kwargs)
         char_assigner.run(port=5001)

--- a/oot3dhdtextgenerator/cli/learning_dataset_generator_cli.py
+++ b/oot3dhdtextgenerator/cli/learning_dataset_generator_cli.py
@@ -63,12 +63,14 @@ class LearningDatasetGeneratorCli(UtilityCli):
         # Output arguments
         arg_groups["output arguments"].add_argument(
             "--train_outfile",
+            dest="train_out_path",
             type=output_file_arg(),
             default="train_{n_chars}.h5",
             help="train output file (default: %(default)s)",
         )
         arg_groups["output arguments"].add_argument(
             "--test_outfile",
+            dest="test_out_path",
             type=output_file_arg(),
             default="test_{n_chars}.h5",
             help="test output file (default: %(default)s)",
@@ -85,11 +87,11 @@ class LearningDatasetGeneratorCli(UtilityCli):
             **kwargs: Keyword arguments
         """
         utility_cls = cls.utility()
-        kwargs["train_outfile"] = validate_output_file(
-            str(kwargs["train_outfile"]).format(**kwargs)
+        kwargs["train_out_path"] = validate_output_file(
+            str(kwargs["train_out_path"]).format(**kwargs)
         )
-        kwargs["test_outfile"] = validate_output_file(
-            str(kwargs["test_outfile"]).format(**kwargs)
+        kwargs["test_out_path"] = validate_output_file(
+            str(kwargs["test_out_path"]).format(**kwargs)
         )
         utility_cls.run(**kwargs)
 

--- a/oot3dhdtextgenerator/cli/model_trainer_cli.py
+++ b/oot3dhdtextgenerator/cli/model_trainer_cli.py
@@ -53,12 +53,14 @@ class ModelTrainerCli(UtilityCli):
         )
         arg_groups["input arguments"].add_argument(
             "--train-infile",
+            dest="train_in_path",
             type=input_file_arg(must_exist=False),
             default="train_{n_chars}.h5",
             help="train data input file (default: %(default)s)",
         )
         arg_groups["input arguments"].add_argument(
             "--test-infile",
+            dest="test_in_path",
             type=input_file_arg(must_exist=False),
             default="test_{n_chars}.h5",
             help="test data input file (default: %(default)s)",
@@ -131,6 +133,7 @@ class ModelTrainerCli(UtilityCli):
         )
         arg_groups["output arguments"].add_argument(
             "--model-outfile",
+            dest="model_out_path",
             type=output_file_arg(),
             default="model_{n_chars}.pth",
             help="model output file (default: %(default)s)",
@@ -147,14 +150,14 @@ class ModelTrainerCli(UtilityCli):
             **kwargs: Keyword arguments
         """
         utility_cls = cls.utility()
-        kwargs["train_infile"] = validate_input_file(
-            str(kwargs["train_infile"]).format(**kwargs)
+        kwargs["train_in_path"] = validate_input_file(
+            str(kwargs["train_in_path"]).format(**kwargs)
         )
-        kwargs["test_infile"] = validate_input_file(
-            str(kwargs["test_infile"]).format(**kwargs)
+        kwargs["test_in_path"] = validate_input_file(
+            str(kwargs["test_in_path"]).format(**kwargs)
         )
-        kwargs["model_outfile"] = validate_output_file(
-            str(kwargs["model_outfile"]).format(**kwargs)
+        kwargs["model_out_path"] = validate_output_file(
+            str(kwargs["model_out_path"]).format(**kwargs)
         )
         kwargs.pop("n_chars")
         utility_cls.run(**kwargs)

--- a/oot3dhdtextgenerator/core/learning_dataset.py
+++ b/oot3dhdtextgenerator/core/learning_dataset.py
@@ -43,24 +43,24 @@ class LearningDataset(VisionDataset):
 
     def __init__(
         self,
-        infile: PathLike,
+        in_path: PathLike,
         transform: Callable | None = None,
         target_transform: Callable | None = None,
     ) -> None:
         """Initialize.
 
         Arguments:
-            infile: Path to HDF5 file
+            in_path: Path to HDF5 file
             transform: Transform to apply to images
             target_transform: Transform to apply to targets
         """
-        infile = validate_input_file(infile)
+        in_path = validate_input_file(in_path)
         super().__init__(
-            str(infile.parent),
+            str(in_path.parent),
             transform=transform,
             target_transform=target_transform,
         )
-        self.images, self.specifications = self.load_hdf5(infile)
+        self.images, self.specifications = self.load_hdf5(in_path)
 
     def __getitem__(self, index: int) -> tuple[np.ndarray, int]:
         """Get image and target at index."""
@@ -135,21 +135,21 @@ class LearningDataset(VisionDataset):
     @classmethod
     def load_hdf5(
         cls,
-        infile: Path,
+        in_path: Path,
     ) -> tuple[np.ndarray, np.ndarray]:
         """Load images and specifications from an HDF5 file.
 
         Arguments:
-            infile: Path to HDF5 infile
+            in_path: Path to HDF5 infile
         Returns:
             Train images, train specifications, test images, and test specifications
         Raises:
-            ValueError: If infile does not contain images and specifications
+            ValueError: If in_path does not contain images and specifications
         """
-        with h5py.File(infile, "r") as h5_file:
+        with h5py.File(in_path, "r") as h5_file:
             if "images" not in h5_file or "specifications" not in h5_file:
                 raise ValueError(
-                    f"HDF5{infile} does not contain images and specifications"
+                    f"HDF5{in_path} does not contain images and specifications"
                 )
 
             images = np.array(h5_file["images"])
@@ -163,16 +163,16 @@ class LearningDataset(VisionDataset):
         cls,
         images: np.ndarray,
         specifications: np.ndarray,
-        outfile: Path,
+        out_path: Path,
     ) -> None:
         """Save images and specifications to an HDF5 file.
 
         Arguments:
             images: Train images
             specifications: Train image specifications
-            outfile: Path to HDF5 outfile
+            out_path: Path to HDF5 outfile
         """
-        with h5py.File(outfile, "w") as h5_file:
+        with h5py.File(out_path, "w") as h5_file:
             if "images" in h5_file:
                 del h5_file["images"]
             h5_file.create_dataset(

--- a/oot3dhdtextgenerator/image/oot3d_text_processor.py
+++ b/oot3dhdtextgenerator/image/oot3d_text_processor.py
@@ -21,22 +21,38 @@ class OOT3DHDTextProcessor(ImageProcessor):
 
     def __init__(
         self,
-        assignment_file: PathLike,
+        assignment_path: PathLike,
         font: str = r"C:\Windows\Fonts\simhei.ttf",
         size: int = 48,
         offset: tuple[int, int] = (0, 0),
         **kwargs: Any,
-    ):
+    ) -> None:
+        """Initialize the processor.
+
+        Arguments:
+            assignment_path: Assignment dataset path
+            font: Font name
+            size: Font size
+            offset: Starting offset
+            **kwargs: Additional keyword arguments
+        """
         super().__init__(**kwargs)
 
-        self.assignment_file = validate_output_file(assignment_file, may_exist=True)
-        self.assignment_dataset = AssignmentDataset(self.assignment_file)
+        self.assignment_path = validate_output_file(assignment_path, may_exist=True)
+        self.assignment_dataset = AssignmentDataset(self.assignment_path)
 
         self.font = ImageFont.truetype(font, validate_int(size, 1))
         self.size = validate_int(size, 1)
         self.offset = offset
 
     def __call__(self, input_image: Image.Image) -> Image.Image:
+        """Process an image.
+
+        Arguments:
+            input_image: Input image
+        Returns:
+            Processed image
+        """
         array = np.array(input_image)[:, :, 3]
         chars = self.assignment_dataset.get_chars_for_multi_char_array(array)
         if chars is None:
@@ -47,7 +63,7 @@ class OOT3DHDTextProcessor(ImageProcessor):
 
     def __repr__(self) -> str:
         """Representation."""
-        return f"{self.__class__.__name__}(assignment_file={self.assignment_file!r})"
+        return f"{self.__class__.__name__}(assignment_path={self.assignment_path!r})"
 
     def create_image(self, input_image, characters: list[str]) -> Image.Image:
         """Create image from characters.
@@ -85,9 +101,9 @@ class OOT3DHDTextProcessor(ImageProcessor):
         self.assignment_dataset.save_hdf5(
             self.assignment_dataset.assigned_char_bytes,
             self.assignment_dataset.unassigned_char_bytes,
-            self.assignment_file,
+            self.assignment_path,
         )
-        info(f"Saved assignments to {self.assignment_file}")
+        info(f"Saved assignments to {self.assignment_path}")
 
     @classmethod
     def help_markdown(cls) -> str:

--- a/oot3dhdtextgenerator/utilities/learning_dataset_generator.py
+++ b/oot3dhdtextgenerator/utilities/learning_dataset_generator.py
@@ -89,16 +89,16 @@ class LearningDatasetGenerator(Utility):
         cls,
         n_chars: int,
         test_proportion: float,
-        train_outfile: Path,
-        test_outfile: Path,
+        train_out_path: Path,
+        test_out_path: Path,
     ) -> None:
         """Execute.
 
         Arguments:
             n_chars: Number of unique characters to include in dataset
             test_proportion: Proportion of dataset to be set aside for testing
-            train_outfile: Train output file path
-            test_outfile: Test output file path
+            train_out_path: Train output file path
+            test_out_path: Test output file path
         """
         images, specifications = cls.generate_character_images(n_chars)
         info(f"Generated {images.shape[0]} character images")
@@ -113,13 +113,13 @@ class LearningDatasetGenerator(Utility):
             f"{test_images.shape[0]} test images"
         )
 
-        LearningDataset.save_hdf5(train_images, train_specifications, train_outfile)
-        info(f"Saved {train_images.shape[0]} character images to {train_outfile}")
-        LearningDataset.save_hdf5(test_images, test_specifications, test_outfile)
-        info(f"Saved {test_images.shape[0]} character images to {test_outfile}")
+        LearningDataset.save_hdf5(train_images, train_specifications, train_out_path)
+        info(f"Saved {train_images.shape[0]} character images to {train_out_path}")
+        LearningDataset.save_hdf5(test_images, test_specifications, test_out_path)
+        info(f"Saved {test_images.shape[0]} character images to {test_out_path}")
 
     @staticmethod
-    def generate_character_image(
+    def generate_character_image(  # noqa: PLR0913
         char: str,
         *,
         font: str = r"C:\Windows\Fonts\simhei.ttf",

--- a/oot3dhdtextgenerator/utilities/model_trainer.py
+++ b/oot3dhdtextgenerator/utilities/model_trainer.py
@@ -22,11 +22,11 @@ class ModelTrainer(Utility):
     """Optical character recognition model trainer."""
 
     @classmethod
-    def run(
+    def run(  # noqa: PLR0913
         cls,
         *,
-        train_infile: Path,
-        test_infile: Path,
+        train_in_path: Path,
+        test_in_path: Path,
         batch_size: int = 64,
         test_batch_size: int = 1000,
         epochs: int = 1,
@@ -37,13 +37,13 @@ class ModelTrainer(Utility):
         dry_run: bool = False,
         seed: int = 1,
         log_interval: int = 10,
-        model_outfile: Path,
+        model_out_path: Path,
     ) -> None:
         """Execute from command line.
 
         Arguments:
-            train_infile: Train data input file
-            test_infile: Test data input file
+            train_in_path: Train data input file
+            test_in_path: Test data input file
             batch_size: Batch size for training
             test_batch_size: Batch size for testing
             epochs: Number of epochs to train
@@ -54,7 +54,7 @@ class ModelTrainer(Utility):
             dry_run: Whether to check a single pass
             seed: Random seed
             log_interval: Training status logging interval
-            model_outfile: Model output file
+            model_out_path: Model output file
         """
         # Determine which device to use
         cuda_enabled = torch.cuda.is_available() and cuda_enabled
@@ -76,9 +76,9 @@ class ModelTrainer(Utility):
 
         # Load training and test data
         transform = Compose([ToTensor(), Normalize((0.1307,), (0.3081,))])
-        train_dataset = LearningDataset(train_infile, transform=transform)
+        train_dataset = LearningDataset(train_in_path, transform=transform)
         train_loader = DataLoader(train_dataset, **train_loader_kwargs)
-        test_dataset = LearningDataset(test_infile, transform=transform)
+        test_dataset = LearningDataset(test_in_path, transform=transform)
         test_loader = DataLoader(test_dataset, **test_loader_kwargs)
 
         # Configure model
@@ -102,8 +102,8 @@ class ModelTrainer(Utility):
             scheduler.step()
 
         # Save model
-        torch.save(model.state_dict(), model_outfile)
-        info(f"{cls}: Model saved to {model_outfile}")
+        torch.save(model.state_dict(), model_out_path)
+        info(f"{cls}: Model saved to {model_out_path}")
 
     @staticmethod
     def test(model: Model, device: torch.device, loader: DataLoader) -> None:
@@ -119,7 +119,7 @@ class ModelTrainer(Utility):
         correct = 0
         with torch.no_grad():
             for data, target in loader:
-                data, target = data.to(device), target.to(device)
+                data, target = data.to(device), target.to(device)  # noqa: PLW2901
                 output = model(data)
                 test_loss += nll_loss(output, target, reduction="sum").item()
                 pred = output.argmax(dim=1, keepdim=True)
@@ -132,7 +132,7 @@ class ModelTrainer(Utility):
         )
 
     @staticmethod
-    def train(
+    def train(  # noqa: PLR0913
         model: Model,
         device: torch.device,
         loader: DataLoader,
@@ -155,7 +155,7 @@ class ModelTrainer(Utility):
         """
         model.train()
         for batch_idx, (data, target) in enumerate(loader):
-            data, target = data.to(device), target.to(device)
+            data, target = data.to(device), target.to(device)  # noqa: PLW2901
             optimizer.zero_grad()
             output = model(data)
             loss = nll_loss(output, target)


### PR DESCRIPTION
## Summary
- rename path-related parameters and variables to use `_path`
- update CLI argument destinations to match new parameter names
- update dataset classes, utilities, and image processor accordingly
- add missing docstrings and suppress ruff warnings

## Testing
- `uv run ruff format oot3dhdtextgenerator/apps/char_assigner/char_assigner.py oot3dhdtextgenerator/apps/char_assigner/routes.py oot3dhdtextgenerator/cli/char_assigner_cli.py oot3dhdtextgenerator/cli/learning_dataset_generator_cli.py oot3dhdtextgenerator/cli/model_trainer_cli.py oot3dhdtextgenerator/core/assignment_dataset.py oot3dhdtextgenerator/core/learning_dataset.py oot3dhdtextgenerator/image/oot3d_text_processor.py oot3dhdtextgenerator/utilities/learning_dataset_generator.py oot3dhdtextgenerator/utilities/model_trainer.py`
- `uv run ruff check --fix oot3dhdtextgenerator/apps/char_assigner/char_assigner.py oot3dhdtextgenerator/apps/char_assigner/routes.py oot3dhdtextgenerator/cli/char_assigner_cli.py oot3dhdtextgenerator/cli/learning_dataset_generator_cli.py oot3dhdtextgenerator/cli/model_trainer_cli.py oot3dhdtextgenerator/core/assignment_dataset.py oot3dhdtextgenerator/core/learning_dataset.py oot3dhdtextgenerator/image/oot3d_text_processor.py oot3dhdtextgenerator/utilities/learning_dataset_generator.py oot3dhdtextgenerator/utilities/model_trainer.py`
- `uv run pyright`
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791b58cbb083258d8b1fc7fb06d597