### PR TITLE
Add typed RGBA constant

### DIFF
--- a/oot3dhdtextgenerator/image/oot3d_shadow_processor.py
+++ b/oot3dhdtextgenerator/image/oot3d_shadow_processor.py
@@ -8,6 +8,8 @@ import numpy as np
 from PIL import Image
 from pipescaler.image.operators.processors import PotraceProcessor
 
+from oot3dhdtextgenerator.image.typing import RGBA
+
 
 class OOT3DShadowProcessor(PotraceProcessor):
     """Processes shadow images."""
@@ -28,8 +30,9 @@ class OOT3DShadowProcessor(PotraceProcessor):
         super().__init__(arguments=arguments, invert=invert, scale=scale)
 
     def __call__(self, input_image: Image.Image) -> Image.Image:
+        """Process shadow image and return traced output."""
         # Flatten image and convert to monochrome
-        canvas = Image.new("RGBA", input_image.size, (255, 255, 255))
+        canvas = Image.new(RGBA, input_image.size, (255, 255, 255))
         composite = Image.alpha_composite(canvas, input_image)
         monochrome_image = composite.point(lambda p: p > 240 and 255)
 
@@ -56,12 +59,12 @@ class OOT3DShadowProcessor(PotraceProcessor):
     def inputs(cls) -> dict[str, tuple[str, ...]]:
         """Inputs to this operator."""
         return {
-            "input": ("RGBA",),
+            "input": (RGBA,),
         }
 
     @classmethod
     def outputs(cls) -> dict[str, tuple[str, ...]]:
         """Outputs of this operator."""
         return {
-            "output": ("RGBA",),
+            "output": (RGBA,),
         }

--- a/oot3dhdtextgenerator/image/oot3d_text_processor.py
+++ b/oot3dhdtextgenerator/image/oot3d_text_processor.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from logging import info
 from typing import Any
 
@@ -14,6 +15,7 @@ from pipescaler.image.core.operators import ImageProcessor
 from oot3dhdtextgenerator.common.typing import PathLike
 from oot3dhdtextgenerator.common.validation import validate_int, validate_output_file
 from oot3dhdtextgenerator.core import AssignmentDataset
+from oot3dhdtextgenerator.image.typing import RGBA
 
 
 class OOT3DHDTextProcessor(ImageProcessor):
@@ -27,6 +29,7 @@ class OOT3DHDTextProcessor(ImageProcessor):
         offset: tuple[int, int] = (0, 0),
         **kwargs: Any,
     ):
+        """Initialize the processor."""
         super().__init__(**kwargs)
 
         self.assignment_file = validate_output_file(assignment_file, may_exist=True)
@@ -37,6 +40,7 @@ class OOT3DHDTextProcessor(ImageProcessor):
         self.offset = offset
 
     def __call__(self, input_image: Image.Image) -> Image.Image:
+        """Process image and create HD text image."""
         array = np.array(input_image)[:, :, 3]
         chars = self.assignment_dataset.get_chars_for_multi_char_array(array)
         if chars is None:
@@ -49,12 +53,12 @@ class OOT3DHDTextProcessor(ImageProcessor):
         """Representation."""
         return f"{self.__class__.__name__}(assignment_file={self.assignment_file!r})"
 
-    def create_image(self, input_image, characters: list[str]) -> Image.Image:
+    def create_image(self, input_image, characters: Sequence[str]) -> Image.Image:
         """Create image from characters.
 
         Arguments:
             input_image (Image.Image): Input image
-            characters (list[str]): Characters to draw
+            characters (Sequence[str]): Characters to draw
         Returns:
             Image.Image: Output image
         """
@@ -76,7 +80,7 @@ class OOT3DHDTextProcessor(ImageProcessor):
             (input_image.size[0] * 4, input_image.size[1] * 4, 4), dtype=np.uint8
         )
         output_array[:, :, 3] = np.array(output_image_alpha)
-        output_image = Image.fromarray(output_array, mode="RGBA")
+        output_image = Image.fromarray(output_array, mode=RGBA)
 
         return output_image
 
@@ -98,12 +102,12 @@ class OOT3DHDTextProcessor(ImageProcessor):
     def inputs(cls) -> dict[str, tuple[str, ...]]:
         """Inputs to this operator."""
         return {
-            "input": ("RGBA",),
+            "input": (RGBA,),
         }
 
     @classmethod
     def outputs(cls) -> dict[str, tuple[str, ...]]:
         """Outputs of this operator."""
         return {
-            "output": ("RGBA",),
+            "output": (RGBA,),
         }

--- a/oot3dhdtextgenerator/image/typing.py
+++ b/oot3dhdtextgenerator/image/typing.py
@@ -1,0 +1,13 @@
+#  Copyright 2020-2025 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Type definitions for image utilities."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+ImageMode = Literal["RGBA"]
+"""Supported image mode."""
+
+RGBA: ImageMode = "RGBA"
+"""RGBA image mode constant."""


### PR DESCRIPTION
## Summary
- replace ImageMode enum with a Literal alias and RGBA constant
- revert to using plain 'input' and 'output' keys
- update processors to use new RGBA constant

## Testing
- `uv run ruff format oot3dhdtextgenerator/image/typing.py oot3dhdtextgenerator/image/oot3d_shadow_processor.py oot3dhdtextgenerator/image/oot3d_text_processor.py`
- `uv run ruff check --fix oot3dhdtextgenerator/image/typing.py oot3dhdtextgenerator/image/oot3d_shadow_processor.py oot3dhdtextgenerator/image/oot3d_text_processor.py`
- `uv run ruff check oot3dhdtextgenerator/image/typing.py oot3dhdtextgenerator/image/oot3d_shadow_processor.py oot3dhdtextgenerator/image/oot3d_text_processor.py`
- `uv run pyright oot3dhdtextgenerator/image/typing.py oot3dhdtextgenerator/image/oot3d_shadow_processor.py oot3dhdtextgenerator/image/oot3d_text_processor.py`
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68791b5884d08325a26b00187d412443