### PR TITLE
Implement Python 3.13 conveniences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python: =3.11](https://img.shields.io/badge/python-3.11-green.svg)](https://docs.python.org/3/whatsnew/3.11.html)
+[![Python: =3.13](https://img.shields.io/badge/python-3.13-green.svg)](https://docs.python.org/3/whatsnew/3.13.html)
 [![Build](https://github.com/KarlTDebiec/OOT3DHDTextGenerator/actions/workflows/build.yml/badge.svg)](https://github.com/KarlTDebiec/OOT3DHDTextGenerator/actions/workflows/build.yml)
 [![Coverage](https://img.shields.io/badge/coverage-39-red)](https://github.com/KarlTDebiec/PipeScaler)
 [![Code Style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/oot3dhdtextgenerator/apps/char_assigner/character.py
+++ b/oot3dhdtextgenerator/apps/char_assigner/character.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 from base64 import b64encode
+from dataclasses import dataclass
+from functools import cached_property
 from io import BytesIO
 
 import numpy as np
@@ -12,47 +14,27 @@ from PIL import Image
 from PIL.ImageOps import invert
 
 
+@dataclass(slots=True)
 class Character:
     """Character and its associated metadata."""
 
-    def __init__(
-        self,
-        character_id: int,
-        array: np.ndarray,
-        assignment: str | None = None,
-        predictions: list[str] | None = None,
-    ) -> None:
-        """Initialize.
+    id: int
+    array: np.ndarray
+    assignment: str | None = None
+    predictions: list[str] | None = None
 
-        Arguments:
-            character_id: Integer identifier for the character.
-            array: Array representation of the character image.
-            assignment: Assigned value, if any.
-            predictions: Potential assignments, if any.
-        Returns:
-            None
-        """
-        self.id = character_id
-        self.array = array
-        self.assignment = assignment
-        self._image = None
-        self.predictions = predictions
-
-    @property
+    @cached_property
     def image(self) -> str:
         """Base64 encoded PNG representation of the character.
 
         Returns:
             Base64 encoded image string.
         """
-        if self._image is None:
-            image = Image.fromarray(self.array)
-            image = invert(image)
+        image = Image.fromarray(self.array)
+        image = invert(image)
 
-            image_io = BytesIO()
-            image.save(image_io, format="PNG")
-            b64_image = b64encode(image_io.getvalue()).decode("ascii")
+        image_io = BytesIO()
+        image.save(image_io, format="PNG")
+        b64_image = b64encode(image_io.getvalue()).decode("ascii")
 
-            self._image = f"data:image/png;base64,{b64_image}"
-
-        return self._image
+        return f"data:image/png;base64,{b64_image}"

--- a/oot3dhdtextgenerator/cli/char_assigner_cli.py
+++ b/oot3dhdtextgenerator/cli/char_assigner_cli.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, BooleanOptionalAction
 from typing import Any
 
 from oot3dhdtextgenerator.apps import CharAssigner
@@ -60,18 +60,18 @@ class CharAssignerCli(CommandLineInterface):
 
         # Operation arguments
         arg_groups["operation arguments"].add_argument(
-            "--disable-cuda",
+            "--cuda",
             dest="cuda_enabled",
-            action="store_false",
+            action=BooleanOptionalAction,
             default=True,
-            help="disable CUDA",
+            help="enable or disable CUDA",
         )
         arg_groups["operation arguments"].add_argument(
-            "--disable-mps",
+            "--mps",
             dest="mps_enabled",
-            action="store_false",
+            action=BooleanOptionalAction,
             default=True,
-            help="disable macOS GPU",
+            help="enable or disable macOS GPU",
         )
 
     @classmethod

--- a/oot3dhdtextgenerator/cli/model_trainer_cli.py
+++ b/oot3dhdtextgenerator/cli/model_trainer_cli.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser
+from argparse import ArgumentParser, BooleanOptionalAction
 from typing import Any
 
 from pipescaler.core.cli import UtilityCli
@@ -102,18 +102,18 @@ class ModelTrainerCli(UtilityCli):
             help="random seed (default: %(default)d)",
         )
         arg_groups["operation arguments"].add_argument(
-            "--disable-cuda",
+            "--cuda",
             dest="cuda_enabled",
-            action="store_false",
+            action=BooleanOptionalAction,
             default=True,
-            help="disable CUDA",
+            help="enable or disable CUDA",
         )
         arg_groups["operation arguments"].add_argument(
-            "--disable-mps",
+            "--mps",
             dest="mps_enabled",
-            action="store_false",
+            action=BooleanOptionalAction,
             default=True,
-            help="disable macOS GPU",
+            help="enable or disable macOS GPU",
         )
         arg_groups["operation arguments"].add_argument(
             "--dry-run",


### PR DESCRIPTION
## Summary
- switch README badge to Python 3.13
- convert `Character` class to a dataclass and cache image generation
- use argparse `BooleanOptionalAction` for CUDA/MPS flags

## Testing
- `uv run ruff format oot3dhdtextgenerator/apps/char_assigner/character.py oot3dhdtextgenerator/cli/char_assigner_cli.py oot3dhdtextgenerator/cli/model_trainer_cli.py`
- `uv run ruff check --fix oot3dhdtextgenerator/apps/char_assigner/character.py oot3dhdtextgenerator/cli/char_assigner_cli.py oot3dhdtextgenerator/cli/model_trainer_cli.py`
- `uv run pyright oot3dhdtextgenerator/apps/char_assigner/character.py oot3dhdtextgenerator/cli/char_assigner_cli.py oot3dhdtextgenerator/cli/model_trainer_cli.py`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6879324d4d0c8325aaba0ace9bc9a112