### PR TITLE
Move annotation-only imports under TYPE_CHECKING

### DIFF
--- a/oot3dhdtextgenerator/apps/char_assigner/char_assigner.py
+++ b/oot3dhdtextgenerator/apps/char_assigner/char_assigner.py
@@ -4,8 +4,7 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import torch
@@ -17,6 +16,9 @@ from oot3dhdtextgenerator.core import AssignmentDataset, Model
 
 from .character import Character
 from .routes import route
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class CharAssigner:

--- a/oot3dhdtextgenerator/apps/char_assigner/character.py
+++ b/oot3dhdtextgenerator/apps/char_assigner/character.py
@@ -8,10 +8,13 @@ from base64 import b64encode
 from dataclasses import dataclass
 from functools import cached_property
 from io import BytesIO
+from typing import TYPE_CHECKING
 
-import numpy as np
 from PIL import Image
 from PIL.ImageOps import invert
+
+if TYPE_CHECKING:
+    import numpy as np
 
 
 @dataclass(slots=True)

--- a/oot3dhdtextgenerator/cli/char_assigner_cli.py
+++ b/oot3dhdtextgenerator/cli/char_assigner_cli.py
@@ -5,8 +5,7 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from oot3dhdtextgenerator.apps import CharAssigner
 from oot3dhdtextgenerator.common import CommandLineInterface
@@ -16,6 +15,9 @@ from oot3dhdtextgenerator.common.argument_parsing import (
     int_arg,
 )
 from oot3dhdtextgenerator.common.validation import val_input_path
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
 
 
 class CharAssignerCli(CommandLineInterface):

--- a/oot3dhdtextgenerator/cli/learning_dataset_generator_cli.py
+++ b/oot3dhdtextgenerator/cli/learning_dataset_generator_cli.py
@@ -5,8 +5,7 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from pipescaler.core.cli import UtilityCli
 
@@ -18,6 +17,9 @@ from oot3dhdtextgenerator.common.argument_parsing import (
 )
 from oot3dhdtextgenerator.common.validation import val_output_path
 from oot3dhdtextgenerator.utilities import LearningDatasetGenerator
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
 
 # TODO: Expose settings for image font, sizes, offsets, fills, and rotations
 

--- a/oot3dhdtextgenerator/cli/model_trainer_cli.py
+++ b/oot3dhdtextgenerator/cli/model_trainer_cli.py
@@ -5,8 +5,7 @@
 
 from __future__ import annotations
 
-from argparse import ArgumentParser
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from pipescaler.core.cli import UtilityCli
 
@@ -20,6 +19,9 @@ from oot3dhdtextgenerator.common.validation import (
     val_output_path,
 )
 from oot3dhdtextgenerator.utilities import ModelTrainer
+
+if TYPE_CHECKING:
+    from argparse import ArgumentParser
 
 
 class ModelTrainerCli(UtilityCli):

--- a/oot3dhdtextgenerator/common/argument_parsing.py
+++ b/oot3dhdtextgenerator/common/argument_parsing.py
@@ -9,9 +9,7 @@ from argparse import (
     ArgumentTypeError,
     _ArgumentGroup,  # noqa pylint
 )
-from collections.abc import Callable, Collection
-from pathlib import Path
-from typing import Any, TypedDict, Unpack
+from typing import TYPE_CHECKING, Any, TypedDict, Unpack
 
 from .validation import (
     val_float,
@@ -22,6 +20,10 @@ from .validation import (
     val_output_path,
     val_str,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
+    from pathlib import Path
 
 __all__ = [
     "FloatValidatorKwargs",

--- a/oot3dhdtextgenerator/common/file.py
+++ b/oot3dhdtextgenerator/common/file.py
@@ -4,13 +4,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator
 from contextlib import contextmanager
 from logging import getLogger
 from os import remove
 from pathlib import Path
 from shutil import move, rmtree
 from tempfile import NamedTemporaryFile, mkdtemp
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 __all__ = [
     "get_temp_directory_path",

--- a/oot3dhdtextgenerator/common/subprocess.py
+++ b/oot3dhdtextgenerator/common/subprocess.py
@@ -4,9 +4,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from subprocess import PIPE, Popen, TimeoutExpired
 from threading import Thread
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 def run_command(

--- a/oot3dhdtextgenerator/core/assignment_dataset.py
+++ b/oot3dhdtextgenerator/core/assignment_dataset.py
@@ -4,18 +4,22 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
 from logging import debug, info
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import h5py
 import numpy as np
 from PIL import Image
-from torch import Tensor
 from torchvision.datasets import VisionDataset
 from torchvision.transforms import Compose, Normalize, ToTensor
 
 from oot3dhdtextgenerator.common.validation import val_output_path
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from torch import Tensor
 
 
 class AssignmentDataset(VisionDataset):

--- a/oot3dhdtextgenerator/core/learning_dataset.py
+++ b/oot3dhdtextgenerator/core/learning_dataset.py
@@ -4,8 +4,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import h5py
 import numpy as np
@@ -14,6 +13,10 @@ from torchvision.datasets import VisionDataset
 
 from oot3dhdtextgenerator.common.validation import val_input_path
 from oot3dhdtextgenerator.data import character_to_index
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
 
 
 class LearningDataset(VisionDataset):

--- a/oot3dhdtextgenerator/utilities/learning_dataset_generator.py
+++ b/oot3dhdtextgenerator/utilities/learning_dataset_generator.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 import time
 from itertools import product
 from logging import info
-from pathlib import Path
 from random import sample
+from typing import TYPE_CHECKING
 
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
@@ -16,6 +16,9 @@ from pipescaler.core import Utility
 
 from oot3dhdtextgenerator.core import LearningDataset
 from oot3dhdtextgenerator.data import hanzi_frequency
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class LearningDatasetGenerator(Utility):

--- a/oot3dhdtextgenerator/utilities/model_trainer.py
+++ b/oot3dhdtextgenerator/utilities/model_trainer.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from logging import info
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import torch
 from pipescaler.core import Utility
@@ -16,6 +16,9 @@ from torch.utils.data import DataLoader
 from torchvision.transforms import Compose, Normalize, ToTensor
 
 from oot3dhdtextgenerator.core import LearningDataset, Model
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class ModelTrainer(Utility):

--- a/test/common/file/test_rename_preexisting_output_path.py
+++ b/test/common/file/test_rename_preexisting_output_path.py
@@ -4,9 +4,12 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 from common.file import rename_preexisting_output_path  # ty:ignore[unresolved-import]
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_rename_preexisting_output_path_no_existing_file(tmp_path: Path):

--- a/test/common/test_command_line_interface.py
+++ b/test/common/test_command_line_interface.py
@@ -6,14 +6,16 @@ from __future__ import annotations
 
 from argparse import ArgumentParser
 from logging import getLogger
-from pathlib import Path
-from typing import TypedDict, Unpack
+from typing import TYPE_CHECKING, TypedDict, Unpack
 from unittest.mock import patch
 
 import pytest
 from common.command_line_interface import (  # ty:ignore[unresolved-import]
     CommandLineInterface,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class CliTestKwargs(TypedDict, total=False):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,6 +8,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from inspect import getfile
 from io import StringIO
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pipescaler.testing.mark import parametrize_with_readable_ids
 
@@ -16,8 +17,10 @@ from oot3dhdtextgenerator.cli import (
     LearningDatasetGeneratorCli,
     ModelTrainerCli,
 )
-from oot3dhdtextgenerator.common import CommandLineInterface
 from oot3dhdtextgenerator.common.testing import run_cli_with_args
+
+if TYPE_CHECKING:
+    from oot3dhdtextgenerator.common import CommandLineInterface
 
 
 @parametrize_with_readable_ids(


### PR DESCRIPTION
## Summary
- move annotation-only imports behind `if TYPE_CHECKING:` in runtime and test modules
- resolve all current `TCH*` diagnostics reported by Ruff for this repository
- keep behavior unchanged by limiting edits to import placement

## Validation
- `uv run ruff format <changed-files>`
- `uv run ruff check --fix <changed-files>` *(reports pre-existing non-TCH findings in touched files)*
- `uv run ruff check --select TCH oot3dhdtextgenerator test`
- `cd test && uv run pytest` (178 passed)

Closes #190