### PR TITLE
Add contributor guidance and style audit skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # Instructions
 
+Review [docs/STYLE.md](/docs/STYLE.md) and [docs/ARCHITECTURE.md](/docs/ARCHITECTURE.md) before planning or coding.
+
 ## Tools
 
 * This repository uses a virtual environment. To activate the venv in your shell: `source .venv/bin/activate`.
@@ -12,39 +14,15 @@
 
 ### Linting
 
+* Before running `ruff` or `ty`, check changed files for compliance with [docs/STYLE.md](/docs/STYLE.md).
 * Run the following checks on **only the Python files you have changed or been asked to**:
   1. `uv run ruff format`
   2. `uv run ruff check --fix`
-  3. `uv run ty`
+  3. `uv run ty check`
 * If `ruff` or `ty` suggest changes that would require major refactoring, confirm with the user before proceeding.
 
 ### Testing
 
 * Run the tests as follows:
-  * `cd test && uv run pytest`
+  * `cd test && PYTHONPATH=.. uv run pytest`
 * You may run pytest with a timeout of up to 10 minutes without asking the user.
-
-## Code Style
-
-* Include the standard copyright header at the top of the file.
-* Include a module docstring at the top of each file.
-* Include `from __future__ import annotations`, unless the file is empty.
-* Include type annotations for all function and method signatures, with the following exception:
-    * If a function always returns `None`, omit the return type annotation.
-* Use f-strings for ordinary Python string interpolation.
-  * `.format(...)` may be used when the variables are supplied in a dict.
-* In `__init__.py` files, only import classes from the module, not functions or variables.
-* Use the `logging` module rather than `print` for any user-facing output in scripts or
-  libraries.
-* Test modules do **not** need `__init__.py` files. Pytest can discover tests without them.
-
-## Documentation
-
-* Use Markdown for formatting.
-* Do **not** include any reStructuredText markup such as double backticks.
-* Provide docstrings for all classes and functions, including internal helpers prefixed with an underscore.
-* Format docstrings using Google style, with the following tweaks:
-    * Use "Arguments:" instead of "Args:".
-    * Do not include a blank line between the "Arguments:" and "Returns:" sections.
-    * In argument descriptions, the first word after the colon should be lowercase unless it is a type name.
-    * In the Returns section, the first word should be lowercase unless it is a type name.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,49 @@
+# Architecture
+
+## Purpose
+
+OOT3DHDTextGenerator builds high-resolution replacement text textures for The Legend of Zelda: Ocarina of Time 3D. The package watches or processes texture dumps, identifies the game's generated glyph tiles, maps those tiles to characters, and renders replacement images at a higher scale.
+
+## Package Layout
+
+* `oot3dhdtextgenerator.apps`: Flask-backed tools for inspecting and assigning character images.
+  * `char_assigner`: interactive workflow for assigning unrecognized glyph tiles and reviewing OCR predictions.
+  * `char_inspector`: inspection workflow for browsing known character data.
+* `oot3dhdtextgenerator.cli`: command-line entry points. CLI modules should stay thin: parse arguments, validate paths, format templated defaults, and delegate work to app or utility classes.
+* `oot3dhdtextgenerator.common`: shared infrastructure for argument parsing, CLI base classes, CSV helpers, exceptions, filesystem operations, logging, subprocesses, testing, and validation.
+* `oot3dhdtextgenerator.core`: domain objects and ML primitives, including assignment datasets, training datasets, base64 image conversion, and the OCR model.
+* `oot3dhdtextgenerator.data`: bundled package data, including character lists, assignment CSVs, generated datasets, and model checkpoints.
+* `oot3dhdtextgenerator.image`: image processors that transform dumped texture images into high-resolution replacements.
+* `oot3dhdtextgenerator.utilities`: reusable non-interactive workflows, such as model training and training dataset generation.
+* `test`: pytest tests organized to mirror the package hierarchy where practical.
+
+## Data Flow
+
+1. Texture images from Citra or fixture data are represented as alpha-channel arrays split into fixed 16 by 16 glyph cells.
+2. `AssignmentDataset` records known glyph bytes in `assigned.csv` and unknown glyph bytes in `unassigned.csv`.
+3. Training utilities generate image arrays and specifications for model training from assignment data and bundled character frequency data.
+4. `Model` predicts likely characters for unknown glyphs, with optional prior weighting from character frequencies.
+5. The Flask assignment app presents unknown and assigned glyphs for human review, then writes updated assignment CSVs.
+6. `OOT3DHDTextProcessor` looks up every glyph in a texture, renders the corresponding text with PIL, and returns a scaled RGBA replacement image.
+
+## Dependency Boundaries
+
+* CLI modules may depend on app, core, data, image, utility, and common modules, but should not contain domain-heavy logic.
+* App route modules should stay focused on request handling and presentation; durable state changes should go through app or core classes.
+* Core modules should avoid depending on Flask or CLI concerns.
+* Image processors may depend on core datasets and validation helpers, but should keep filesystem side effects explicit.
+* Common modules should remain broadly reusable and avoid importing from domain-specific packages such as `apps`, `core`, `image`, or `utilities`.
+* Tests may use helpers from `oot3dhdtextgenerator.common.testing`, but production modules should not depend on test code.
+
+## Data and Artifacts
+
+* Treat bundled CSVs, `.npy` arrays, and `.pth` checkpoints as versioned artifacts. Avoid rewriting them incidentally while changing code.
+* Keep generated debug artifacts outside package data unless they are intentionally added as fixtures.
+* When changing data formats, update readers, writers, tests, and docs together so existing artifacts remain understandable.
+
+## Operational Notes
+
+* Prefer deterministic file writes for datasets and CSVs. Write through a temporary file and replace the target where practical.
+* Validate user-provided paths at the boundary using `oot3dhdtextgenerator.common.validation`.
+* Preserve CUDA, MPS, and CPU fallback behavior when changing model-loading or inference paths.
+* Keep Flask apps usable from the CLI without requiring package-level global mutable state.

--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -1,0 +1,100 @@
+# Style Guide
+
+## Python Version
+
+* Target **Python 3.13** features where applicable; do not worry about compatibility with earlier versions.
+
+## Copyright
+
+* Include the standard copyright header at the top of the file.
+
+## Formatting
+
+* Allow `ruff format` to manage code formatting details.
+
+## Imports
+
+* Include `from __future__ import annotations` in Python modules that contain
+  imports, exports, type annotations, functions, or classes. Pure package
+  marker files that contain only a module docstring do not need it.
+* For imports within the same directory, use relative imports (for example, `from .foo import bar`).
+* Do not use relative imports for imports from parent or sibling directories (for example, `from ..foo import bar` or `from .. import foo`).
+* Allow `ruff` to manage import sorting.
+
+## Exports
+
+* Include `__all__` in Python modules that export public names. Pure package
+  marker files that intentionally export nothing do not need it.
+* If `__all__` contains multiple entries, include a trailing comma after the last entry so `ruff` formats it as one item per line.
+* `__all__` should list the **intended public API** for the module.
+  * Do not include internal helpers (names prefixed with an underscore).
+  * Keep `__all__` stable where practical; renames/removals are user-facing changes.
+* In `__init__.py` files, only import classes from the module, not functions or variables.
+
+## Organization
+
+* Within classes, sort methods in the following hierarchy:
+  1. Level 1: `__init__`, other builtins, public properties, public methods, private properties, private methods
+  2. Level 2: standard methods, class methods, static methods
+  3. Level 3: alphabetical order
+* Within modules, sort functions using the same hierarchy described for class methods:
+  1. Level 1: public functions, private functions (prefixed with an underscore)
+  2. Level 2: standard functions, then decorator-based variants where applicable (for example, `@overload`)
+  3. Level 3: alphabetical order
+
+## Nomenclature
+
+* Use explicit path nomenclature:
+  * variables or parameters holding `Path` objects should end in `_path` (for example, `file_path`, `dir_path`, `cache_dir_path`)
+  * bare `path` or `paths` parameters are acceptable for small path-focused helpers where no more specific role name applies
+  * CLI-facing argument names may use conventional command-line terms such as `infile` and `outfile` without a `_path` suffix
+  * generic validator inputs may use `value` or `value_to_validate`, even when the accepted type includes paths
+  * use `*_name` for bare names and `*_stem` for stems, not for full paths
+  * prefer `*_dir_path` over `*_directory` when the value is a path
+
+## Style
+
+* Exclusively use f-strings for ordinary string interpolation.
+  * `.format(...)` may be used when the variables are supplied in a dict, such as templated CLI defaults.
+* Where possible, classes should implement `__repr__` methods such that they may be reconstructed from its `repr` output.
+* Avoid ternary expressions; prefer explicit `if`/`else` statements for readability.
+
+## Type Annotations
+
+* Include type annotations for all function and method signatures, with the following exception:
+  * If a function always returns `None`, omit the return type annotation.
+
+## Exceptions
+
+* Prefer repository-specific exceptions from `oot3dhdtextgenerator.common.exception` for domain-specific errors that should be user-facing.
+* Prefer built-in exceptions (`ValueError`, `TypeError`, etc.) for programming errors or invalid internal state.
+* When wrapping a caught exception, use exception chaining (`raise ... from err`) to preserve context.
+
+## Logging
+
+* Use the `logging` module rather than `print` for any user-facing output in scripts or libraries.
+  * CLI tools may use `print` for intentional command output written to stdout.
+  * Follow the repository pattern of defining a module-level `logger = getLogger(__name__)` when a module needs a logger.
+
+## Testing
+
+* Test modules do **not** need `__init__.py` files. Pytest can discover tests without them.
+* Keep tests close to the module hierarchy under `test/` so package structure and test structure stay easy to compare.
+
+## Documentation
+
+* Include a module docstring at the top of each file.
+* Use Markdown for formatting.
+* Do **not** include any reStructuredText markup such as double backticks.
+* Provide docstrings for all modules, classes, properties, and functions, including internal helpers prefixed with an underscore.
+  * Provide docstrings for property setters as well as getters when they are defined.
+  * Provide docstrings for `TypedDict` classes, enums, and other public type definitions.
+  * `@overload` stubs do not need docstrings when the concrete implementation is documented.
+* Document class attributes using triple-quoted strings immediately below each instead of relying only on an `Attributes` section in the class docstring.
+* Format docstrings using Google style, with the following tweaks:
+  * Use `Arguments:` instead of `Args:`.
+  * Do not include an `Arguments:` section for functions or methods that take no arguments.
+  * In argument descriptions, the first word after the colon should be lowercase unless it is a type name.
+  * Do not include a blank line between the `Arguments:` and `Returns:` sections.
+  * Do not include a `Returns:` section for functions or methods that return None.
+  * In the `Returns:` section, the first word should be lowercase unless it is a type name.

--- a/skills/audit-style/SKILL.md
+++ b/skills/audit-style/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: audit-style
+description: Audit Python files in OOT3DHDTextGenerator for compliance with docs/STYLE.md and write conservative markdown notes, typically to local/style_notes.md. Use when asked to review repository style compliance without automatically modifying source files.
+---
+
+# Audit `docs/STYLE.md` Compliance
+
+Use this workflow to review Python source files against `docs/STYLE.md` and write notes without changing source code.
+
+## Quick Workflow
+
+1. Read `docs/STYLE.md`.
+2. Run the helper script:
+   - `uv run python skills/audit-style/scripts/audit_style.py --target oot3dhdtextgenerator --output local/style_notes.md`
+3. Review the generated markdown report.
+4. If asked to fix issues, edit source files separately and validate only changed Python files:
+   - `uv run ruff format <changed_files>`
+   - `uv run ruff check --fix <changed_files>`
+   - `uv run ty check <changed_files>`
+
+## Notes
+
+* The script is intentionally conservative and flags items that may require maintainer judgment.
+* It does not run `ruff`, `ty`, or tests.
+* It does not exhaustively prove public API intent, method ordering, or whether `print` output is user-facing.
+* Keep generated audit notes under `local/` unless the user asks for a different path.

--- a/skills/audit-style/scripts/audit_style.py
+++ b/skills/audit-style/scripts/audit_style.py
@@ -1,0 +1,1041 @@
+#  Copyright 2017-2026 Karl T Debiec. All rights reserved. This software may be modified
+#  and distributed under the terms of the BSD license. See the LICENSE file for details.
+"""Audit Python files for compliance with `docs/STYLE.md`."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+from collections import Counter, defaultdict
+from collections.abc import Sequence
+from pathlib import Path
+from typing import NamedTuple
+
+__all__ = [
+    "StyleNote",
+    "audit_file",
+    "audit_paths",
+    "get_python_files",
+    "main",
+    "parse_args",
+    "write_report",
+]
+
+PACKAGE_NAME = "oot3dhdtextgenerator"
+"""Package name audited by default."""
+
+COPYRIGHT_LINE_ONE_RE = re.compile(
+    r"^#  Copyright (2017|2020)-2026 Karl T Debiec\. All rights reserved\. "
+    r"This software may be modified$"
+)
+"""Regex matching the first line of the repository copyright header."""
+
+COPYRIGHT_LINE_TWO_RE = re.compile(
+    r"^#  and distributed under the terms of the BSD license\. "
+    r"See the LICENSE file for details\.$"
+)
+"""Regex matching the second line of the repository copyright header."""
+
+PRINT_CALL_RE = re.compile(r"(?<![A-Za-z0-9_])print\s*\(")
+"""Regex matching a likely `print` call."""
+
+RST_DOUBLE_BACKTICK_RE = re.compile(r"``[^`]+``")
+"""Regex matching reStructuredText-style double backticks."""
+
+EXEMPT_RETURN_NONE_NAMES = {"__init__"}
+"""Function names allowed to omit a return annotation despite no returned value."""
+
+
+class StyleNote(NamedTuple):
+    """One style audit note.
+
+    Attributes:
+        category: style category
+        line_number: source line number
+        message: note text
+    """
+
+    category: str
+    """Style category."""
+
+    line_number: int
+    """Source line number."""
+
+    message: str
+    """Note text."""
+
+
+def audit_file(file_path: Path, notes: dict[str, list[StyleNote]]):
+    """Audit a single Python source file.
+
+    Arguments:
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    text = file_path.read_text()
+    lines = text.splitlines()
+    stripped = text.strip()
+    package_name = _package_name_for(file_path)
+
+    _audit_required_header(text, lines, file_path, notes)
+
+    try:
+        tree = ast.parse(text, filename=file_path.as_posix())
+    except SyntaxError as err:
+        _add_note(notes, file_path, "Syntax", err.lineno or 1, err.msg)
+        return
+
+    if stripped:
+        _audit_tree_header(tree, file_path, notes)
+    _audit_tree(tree, file_path, package_name, notes)
+    _audit_text_lines(lines, file_path, notes)
+
+
+def audit_paths(target_path: Path) -> tuple[list[Path], dict[str, list[StyleNote]]]:
+    """Audit all Python files under a target path.
+
+    Arguments:
+        target_path: file or directory path to audit
+    Returns:
+        audited files and notes keyed by POSIX path
+    """
+    files = get_python_files(target_path)
+    notes: dict[str, list[StyleNote]] = defaultdict(list)
+    for file_path in files:
+        audit_file(file_path, notes)
+    return files, notes
+
+
+def get_python_files(target_path: Path) -> list[Path]:
+    """Get Python files under a target file or directory.
+
+    Arguments:
+        target_path: file or directory path
+    Returns:
+        sorted Python file paths
+    """
+    if target_path.is_file():
+        return [target_path] if target_path.suffix == ".py" else []
+    return sorted(target_path.rglob("*.py"))
+
+
+def main(argv: Sequence[str] | None = None):
+    """Run the style audit.
+
+    Arguments:
+        argv: optional argument sequence
+    """
+    args = parse_args(argv)
+    files, notes = audit_paths(args.target)
+    write_report(files, notes, args.output)
+    note_count = sum(len(file_notes) for file_notes in notes.values())
+    print(f"wrote {args.output} with {len(files)} files, {note_count} notes")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Arguments:
+        argv: optional argument sequence
+    Returns:
+        parsed command-line arguments
+    """
+    parser = argparse.ArgumentParser(
+        description="Audit Python files against explicit docs/STYLE.md rules."
+    )
+    parser.add_argument(
+        "--target",
+        default=PACKAGE_NAME,
+        type=Path,
+        help=f"Python file or directory to audit. Default: {PACKAGE_NAME}",
+    )
+    parser.add_argument(
+        "--output",
+        default=Path("local/style_notes.md"),
+        type=Path,
+        help="Markdown report output path. Default: local/style_notes.md",
+    )
+    return parser.parse_args(argv)
+
+
+def write_report(
+    file_paths: Sequence[Path],
+    notes: dict[str, list[StyleNote]],
+    output_path: Path,
+):
+    """Write a markdown style audit report.
+
+    Arguments:
+        file_paths: audited file paths
+        notes: notes keyed by POSIX path
+        output_path: markdown output path
+    """
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    category_counts = Counter(
+        note.category for file_notes in notes.values() for note in file_notes
+    )
+    violating_files = sum(
+        1 for file_path in file_paths if file_path.as_posix() in notes
+    )
+    clean_files = len(file_paths) - violating_files
+
+    lines = [
+        "# OOT3DHDTextGenerator Style Audit Notes",
+        "",
+        f"Generated by a static pass over every Python file under `{PACKAGE_NAME}/`, "
+        "checked against `docs/STYLE.md`. These notes are intentionally "
+        'conservative: items marked "verify" may require human judgment, '
+        "especially public API choices, import locality, method ordering, and "
+        "whether `print` output is user-facing.",
+        "",
+        "## Summary",
+        "",
+        f"- Files checked: {len(file_paths)}",
+        f"- Files with notes: {violating_files}",
+        f"- Files without notes from this pass: {clean_files}",
+        f"- Total notes: {sum(category_counts.values())}",
+        "",
+        "## Notes by Category",
+        "",
+    ]
+    for category, count in sorted(
+        category_counts.items(), key=lambda item: (-item[1], item[0])
+    ):
+        lines.append(f"- {category}: {count}")
+    lines.extend(
+        [
+            "",
+            "## Audit Limitations",
+            "",
+            "- Ruff-managed formatting and import ordering were not run; this pass "
+            "focuses on explicit `docs/STYLE.md` rules visible through source "
+            "inspection.",
+            "- `__all__` contents, intended public API, and `__init__.py` "
+            "class-only exports require maintainer judgment.",
+            "- Method/function ordering was sampled by hierarchy rules but not "
+            "exhaustively proven for semantic groups; review classes and modules "
+            "touched during cleanup.",
+            "- Path nomenclature checks are annotation/name based and may miss "
+            "unannotated path-like values or flag values that are not filesystem "
+            "paths.",
+            "",
+            "## File-by-File Notes",
+            "",
+        ]
+    )
+
+    for file_path in file_paths:
+        file_key = file_path.as_posix()
+        lines.extend([f"### `{file_key}`", ""])
+        if file_key not in notes:
+            lines.append("- No notes from this static pass.")
+        else:
+            sorted_notes = sorted(
+                notes[file_key],
+                key=lambda item: (item.line_number, item.category, item.message),
+            )
+            lines.extend(
+                f"- Line {note.line_number}: **{note.category}** - {note.message}"
+                for note in sorted_notes
+            )
+        lines.append("")
+
+    output_path.write_text("\n".join(lines) + "\n")
+
+
+def _add_note(
+    notes: dict[str, list[StyleNote]],
+    file_path: Path,
+    category: str,
+    line_number: int,
+    message: str,
+):
+    """Add a note to an audit result.
+
+    Arguments:
+        notes: notes keyed by POSIX path
+        file_path: source file path
+        category: style category
+        line_number: source line number
+        message: note text
+    """
+    notes[file_path.as_posix()].append(StyleNote(category, line_number, message))
+
+
+def _arg_nodes(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[ast.arg]:
+    """Get all argument nodes from a function definition.
+
+    Arguments:
+        node: function definition
+    Returns:
+        argument nodes
+    """
+    args: list[ast.arg] = []
+    args.extend(node.args.posonlyargs)
+    args.extend(node.args.args)
+    if node.args.vararg:
+        args.append(node.args.vararg)
+    args.extend(node.args.kwonlyargs)
+    if node.args.kwarg:
+        args.append(node.args.kwarg)
+    return args
+
+
+def _audit_class(
+    class_node: ast.ClassDef,
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit a class definition.
+
+    Arguments:
+        class_node: class definition
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    if not _has_docstring(class_node):
+        _add_note(
+            notes,
+            file_path,
+            "Documentation",
+            class_node.lineno,
+            f"missing docstring for class `{class_node.name}`",
+        )
+    _audit_class_attributes(class_node, file_path, notes)
+
+
+def _audit_class_attributes(
+    class_node: ast.ClassDef,
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit documented class attribute declarations.
+
+    Arguments:
+        class_node: class definition
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    for index, item in enumerate(class_node.body):
+        if not isinstance(item, ast.Assign | ast.AnnAssign):
+            continue
+        target = item.target if isinstance(item, ast.AnnAssign) else item.targets[0]
+        name = target.id if isinstance(target, ast.Name) else None
+        if not name or name.startswith("_"):
+            continue
+        next_item = (
+            class_node.body[index + 1] if index + 1 < len(class_node.body) else None
+        )
+        documented = (
+            isinstance(next_item, ast.Expr)
+            and isinstance(next_item.value, ast.Constant)
+            and isinstance(next_item.value.value, str)
+        )
+        if not documented:
+            message = (
+                f"class attribute `{class_node.name}.{name}` lacks immediate "
+                "triple-quoted docstring"
+            )
+            _add_note(notes, file_path, "Documentation", item.lineno, message)
+
+
+def _audit_function(
+    function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit a function or method definition.
+
+    Arguments:
+        function_node: function or method definition
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    if not _is_overload(function_node) and not _has_docstring(function_node):
+        _add_note(
+            notes,
+            file_path,
+            "Documentation",
+            function_node.lineno,
+            f"missing docstring for {_decorated_kind(function_node)} "
+            f"`{function_node.name}`",
+        )
+    _audit_function_annotations(function_node, file_path, notes)
+
+
+def _audit_function_annotations(
+    function_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit annotations on a function or method signature.
+
+    Arguments:
+        function_node: function or method definition
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    for arg in _arg_nodes(function_node):
+        if arg.arg in {"self", "cls"}:
+            continue
+        if arg.annotation is None:
+            message = (
+                f"missing annotation for parameter `{arg.arg}` in "
+                f"`{function_node.name}`"
+            )
+            _add_note(
+                notes, file_path, "Type Annotations", function_node.lineno, message
+            )
+    if function_node.returns is None:
+        value_returns = [
+            node
+            for node in ast.walk(function_node)
+            if isinstance(node, ast.Return)
+            and node.value is not None
+            and not (isinstance(node.value, ast.Constant) and node.value.value is None)
+        ]
+        if value_returns and function_node.name not in EXEMPT_RETURN_NONE_NAMES:
+            _add_note(
+                notes,
+                file_path,
+                "Type Annotations",
+                function_node.lineno,
+                f"missing return annotation for `{function_node.name}`",
+            )
+    elif _returns_none(function_node):
+        _add_note(
+            notes,
+            file_path,
+            "Type Annotations",
+            function_node.lineno,
+            f"omit explicit `-> None` for always-None `{function_node.name}`",
+        )
+
+
+def _audit_import(
+    node: ast.ImportFrom,
+    file_path: Path,
+    package_name: str,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit one `from ... import ...` statement.
+
+    Arguments:
+        node: import node
+        file_path: source file path
+        package_name: current package name
+        notes: notes keyed by POSIX path
+    """
+    if node.module == "__future__":
+        return
+    if node.level >= 2:
+        _add_note(
+            notes,
+            file_path,
+            "Imports",
+            node.lineno,
+            f"parent/sibling relative import uses {node.level} leading dots",
+        )
+    elif node.level == 0 and node.module:
+        imported_module = node.module
+        same_package_import = (
+            imported_module.rsplit(".", 1)[0] == package_name
+            or imported_module == package_name
+        )
+        if imported_module.startswith(f"{PACKAGE_NAME}.") and same_package_import:
+            _add_note(
+                notes,
+                file_path,
+                "Imports",
+                node.lineno,
+                "same-directory import should use relative import",
+            )
+
+
+def _audit_init_export(
+    node: ast.ImportFrom,
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+    public_exports: set[str],
+):
+    """Audit an import from an `__init__.py` file for class-only exports.
+
+    Arguments:
+        node: import node
+        file_path: source file path
+        notes: notes keyed by POSIX path
+        public_exports: names listed in `__all__`
+    """
+    if node.module == "__future__":
+        return
+    for alias in node.names:
+        public_name = alias.asname or alias.name
+        if (
+            public_name != "*"
+            and public_name in public_exports
+            and not public_name[0].isupper()
+        ):
+            message = (
+                "`__init__.py` imports non-class-looking public name "
+                f"`{public_name}`; verify class-only rule"
+            )
+            _add_note(notes, file_path, "Exports", node.lineno, message)
+
+
+def _audit_nomenclature(
+    node: ast.AST,
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit path-related variable and parameter names.
+
+    Arguments:
+        node: AST node
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    if isinstance(node, ast.arg):
+        if (
+            _is_path_annotation(node.annotation)
+            and not (node.arg.endswith("_path") or node.arg.endswith("_paths"))
+            and node.arg not in {"path", "paths"}
+            and not _is_cli_path_argument_name(file_path, node.arg)
+            and not _is_validator_value_name(file_path, node.arg)
+        ):
+            _add_note(
+                notes,
+                file_path,
+                "Nomenclature",
+                node.lineno,
+                f"Path parameter `{node.arg}` should use `_path`/`_paths` suffix",
+            )
+    elif isinstance(node, ast.Assign | ast.AnnAssign):
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        annotation = node.annotation if isinstance(node, ast.AnnAssign) else None
+        for target in targets:
+            if not isinstance(target, ast.Name):
+                continue
+            name = target.id
+            if (
+                _is_path_annotation(annotation)
+                and not (name.endswith("_path") or name.endswith("_paths"))
+                and name not in {"path", "paths"}
+                and not _is_cli_path_argument_name(file_path, name)
+                and not _is_validator_value_name(file_path, name)
+            ):
+                _add_note(
+                    notes,
+                    file_path,
+                    "Nomenclature",
+                    node.lineno,
+                    f"Path variable `{name}` should use `_path`/`_paths` suffix",
+                )
+            if name.endswith("_directory"):
+                replacement_name = f"{name.removesuffix('_directory')}_dir_path"
+                _add_note(
+                    notes,
+                    file_path,
+                    "Nomenclature",
+                    node.lineno,
+                    f"prefer `{replacement_name}` for path-like names",
+                )
+            if name.endswith("_folder"):
+                replacement_name = f"{name.removesuffix('_folder')}_dir_path"
+                _add_note(
+                    notes,
+                    file_path,
+                    "Nomenclature",
+                    node.lineno,
+                    f"prefer `{replacement_name}` for path-like names",
+                )
+
+
+def _audit_required_header(
+    text: str,
+    lines: Sequence[str],
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit file-level copyright requirement.
+
+    Arguments:
+        text: source text
+        lines: source lines
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    if not text.strip():
+        return
+    first_code_line = 1
+    if lines and lines[0].startswith("#!"):
+        first_code_line = 2
+    header_lines = lines[first_code_line - 1 : first_code_line + 1]
+    if len(header_lines) < 2 or not (
+        COPYRIGHT_LINE_ONE_RE.match(header_lines[0])
+        and COPYRIGHT_LINE_TWO_RE.match(header_lines[1])
+    ):
+        _add_note(
+            notes,
+            file_path,
+            "Copyright",
+            first_code_line,
+            "missing or nonstandard two-line copyright header",
+        )
+
+
+def _audit_string_interpolation(
+    node: ast.AST,
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit non-f-string interpolation.
+
+    Arguments:
+        node: AST node
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "format"
+        and _is_string_expr(node.func.value)
+        and not _is_cli_module(file_path)
+    ):
+        _add_note(
+            notes,
+            file_path,
+            "Strings",
+            node.lineno,
+            "uses `.format()` interpolation; prefer f-strings",
+        )
+    if (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Mod)
+        and _is_string_expr(node.left)
+    ):
+        _add_note(
+            notes,
+            file_path,
+            "Strings",
+            node.lineno,
+            "uses `%` interpolation; prefer f-strings",
+        )
+
+
+def _audit_text_lines(
+    lines: Sequence[str],
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit line-oriented text style rules.
+
+    Arguments:
+        lines: source lines
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    allow_print = _is_cli_module(file_path)
+    for line_number, line in enumerate(lines, 1):
+        if not allow_print and PRINT_CALL_RE.search(line):
+            _add_note(
+                notes,
+                file_path,
+                "Logging",
+                line_number,
+                "uses `print`; prefer `logging` outside CLI command output",
+            )
+        if RST_DOUBLE_BACKTICK_RE.search(line):
+            _add_note(
+                notes,
+                file_path,
+                "Documentation",
+                line_number,
+                "contains reStructuredText-style double backticks",
+            )
+
+
+def _audit_tree(
+    tree: ast.Module,
+    file_path: Path,
+    package_name: str,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit AST-oriented style rules.
+
+    Arguments:
+        tree: parsed module
+        file_path: source file path
+        package_name: current package name
+        notes: notes keyed by POSIX path
+    """
+    public_exports = _get_all_exports(tree)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            _audit_import(node, file_path, package_name, notes)
+            if file_path.name == "__init__.py":
+                _audit_init_export(node, file_path, notes, public_exports)
+        elif isinstance(node, ast.ClassDef):
+            _audit_class(node, file_path, notes)
+        elif isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef):
+            _audit_function(node, file_path, notes)
+        _audit_string_interpolation(node, file_path, notes)
+        _audit_nomenclature(node, file_path, notes)
+
+
+def _audit_tree_header(
+    tree: ast.Module,
+    file_path: Path,
+    notes: dict[str, list[StyleNote]],
+):
+    """Audit module docstring and export requirements.
+
+    Arguments:
+        tree: parsed module
+        file_path: source file path
+        notes: notes keyed by POSIX path
+    """
+    if not _has_docstring(tree):
+        _add_note(notes, file_path, "Documentation", 1, "missing module docstring")
+    if _requires_future_annotations(tree) and not _has_future_annotations(tree):
+        _add_note(
+            notes,
+            file_path,
+            "Imports",
+            1,
+            "missing `from __future__ import annotations`",
+        )
+    if _requires_all(tree, file_path) and _get_all_node(tree) is None:
+        _add_note(notes, file_path, "Exports", 1, "missing `__all__`")
+
+
+def _decorated_kind(node: ast.FunctionDef | ast.AsyncFunctionDef) -> str:
+    """Get a display label for a function based on decorators.
+
+    Arguments:
+        node: function or method definition
+    Returns:
+        function kind label
+    """
+    names = _decorator_names(node)
+    if "property" in names:
+        return "property"
+    if "setter" in names:
+        return "property setter"
+    if "classmethod" in names:
+        return "classmethod"
+    if "staticmethod" in names:
+        return "staticmethod"
+    if "overload" in names:
+        return "overload"
+    return "method"
+
+
+def _decorator_names(node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Get decorator names from a function.
+
+    Arguments:
+        node: function or method definition
+    Returns:
+        decorator names
+    """
+    names: list[str] = []
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Name):
+            names.append(target.id)
+        elif isinstance(target, ast.Attribute):
+            names.append(target.attr)
+    return names
+
+
+def _get_all_exports(tree: ast.Module) -> set[str]:
+    """Get names listed in a module's `__all__`.
+
+    Arguments:
+        tree: parsed module
+    Returns:
+        public export names
+    """
+    all_node = _get_all_node(tree)
+    if all_node is None:
+        return set()
+    value = all_node.value
+    if isinstance(value, ast.List | ast.Tuple | ast.Set):
+        return {
+            element.value
+            for element in value.elts
+            if isinstance(element, ast.Constant) and isinstance(element.value, str)
+        }
+    return set()
+
+
+def _get_all_node(tree: ast.Module) -> ast.Assign | ast.AnnAssign | None:
+    """Get a module's `__all__` assignment node.
+
+    Arguments:
+        tree: parsed module
+    Returns:
+        `__all__` assignment, if present
+    """
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "__all__"
+            for target in node.targets
+        ):
+            return node
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__all__"
+        ):
+            return node
+    return None
+
+
+def _get_repo_relative_path(file_path: Path) -> Path:
+    """Get a path relative to the repository root when possible.
+
+    Arguments:
+        file_path: source file path
+    Returns:
+        repository-relative path, or the original path if it is outside cwd
+    """
+    if not file_path.is_absolute():
+        return file_path
+    try:
+        return file_path.relative_to(Path.cwd())
+    except ValueError:
+        return file_path
+
+
+def _has_docstring(
+    node: ast.AsyncFunctionDef | ast.FunctionDef | ast.ClassDef | ast.Module,
+) -> bool:
+    """Check whether an AST node has a docstring.
+
+    Arguments:
+        node: AST node
+    Returns:
+        whether a docstring is present
+    """
+    return ast.get_docstring(node, clean=False) is not None
+
+
+def _has_future_annotations(tree: ast.Module) -> bool:
+    """Check whether a module imports future annotations.
+
+    Arguments:
+        tree: parsed module
+    Returns:
+        whether `from __future__ import annotations` is present
+    """
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(alias.name == "annotations" for alias in node.names)
+        for node in tree.body
+    )
+
+
+def _is_cli_module(file_path: Path) -> bool:
+    """Check whether a file belongs to the CLI package.
+
+    Arguments:
+        file_path: source file path
+    Returns:
+        whether the file is CLI code
+    """
+    parts = _get_repo_relative_path(file_path).parts
+    return (
+        len(parts) >= 2
+        and parts[0] == PACKAGE_NAME
+        and parts[1] == "cli"
+        or parts[:3] == ("skills", "audit-style", "scripts")
+    )
+
+
+def _is_cli_path_argument_name(file_path: Path, name: str) -> bool:
+    """Check whether a name is an allowed CLI path argument name.
+
+    Arguments:
+        file_path: source file path
+        name: variable or parameter name
+    Returns:
+        whether the name may omit a `_path` suffix
+    """
+    return _is_cli_module(file_path) and (
+        name.endswith("infile")
+        or name.endswith("infiles")
+        or name.endswith("outfile")
+        or name.endswith("outfiles")
+    )
+
+
+def _is_overload(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Check whether a function is an overload stub.
+
+    Arguments:
+        node: function or method definition
+    Returns:
+        whether the function is decorated with `@overload`
+    """
+    return "overload" in _decorator_names(node)
+
+
+def _is_path_annotation(annotation: ast.expr | None) -> bool:
+    """Check whether an annotation includes a `Path` type.
+
+    Arguments:
+        annotation: annotation expression
+    Returns:
+        whether the annotation contains `Path` as a type node
+    """
+    is_path = False
+    if annotation is None:
+        pass
+    elif isinstance(annotation, ast.Name):
+        is_path = annotation.id == "Path"
+    elif isinstance(annotation, ast.Attribute):
+        is_path = annotation.attr == "Path"
+    elif isinstance(annotation, ast.BinOp) and isinstance(annotation.op, ast.BitOr):
+        is_path = _is_path_annotation(annotation.left) or _is_path_annotation(
+            annotation.right
+        )
+    elif isinstance(annotation, ast.Constant) and isinstance(annotation.value, str):
+        try:
+            parsed = ast.parse(annotation.value, mode="eval")
+        except SyntaxError:
+            pass
+        else:
+            is_path = _is_path_annotation(parsed.body)
+    elif isinstance(annotation, ast.Subscript):
+        is_path = _is_path_annotation(annotation.slice)
+    elif isinstance(annotation, ast.Tuple):
+        is_path = any(_is_path_annotation(element) for element in annotation.elts)
+    return is_path
+
+
+def _is_pure_package_marker(tree: ast.Module, file_path: Path) -> bool:
+    """Check whether a file is a pure package marker.
+
+    Arguments:
+        tree: parsed module
+        file_path: source file path
+    Returns:
+        whether the file is a docstring-only `__init__.py`
+    """
+    return (
+        file_path.name == "__init__.py"
+        and len(tree.body) == 1
+        and isinstance(tree.body[0], ast.Expr)
+        and isinstance(tree.body[0].value, ast.Constant)
+        and isinstance(tree.body[0].value.value, str)
+    )
+
+
+def _is_string_expr(node: ast.AST) -> bool:
+    """Check whether an expression is a string literal expression.
+
+    Arguments:
+        node: AST node
+    Returns:
+        whether the expression is a string literal
+    """
+    return isinstance(node, ast.Constant) and isinstance(node.value, str)
+
+
+def _is_validator_value_name(file_path: Path, name: str) -> bool:
+    """Check whether a path-like name is an allowed validator input name.
+
+    Arguments:
+        file_path: source file path
+        name: variable or parameter name
+    Returns:
+        whether the name may omit a `_path` suffix
+    """
+    relative_file_path = _get_repo_relative_path(file_path)
+    return (
+        relative_file_path.as_posix() == f"{PACKAGE_NAME}/common/validation.py"
+        and name in {"value", "value_to_validate"}
+    )
+
+
+def _module_name_for(file_path: Path) -> str:
+    """Get the dotted module name for a source file.
+
+    Arguments:
+        file_path: source file path
+    Returns:
+        dotted module name
+    """
+    module_name = file_path.with_suffix("").as_posix().replace("/", ".")
+    if module_name.endswith(".__init__"):
+        return module_name.removesuffix(".__init__")
+    return module_name
+
+
+def _package_name_for(file_path: Path) -> str:
+    """Get the dotted package name for a source file.
+
+    Arguments:
+        file_path: source file path
+    Returns:
+        dotted package name
+    """
+    module_name = _module_name_for(file_path)
+    if file_path.name == "__init__.py":
+        return module_name
+    return module_name.rsplit(".", 1)[0]
+
+
+def _requires_all(tree: ast.Module, file_path: Path) -> bool:
+    """Check whether a module should define `__all__`.
+
+    Arguments:
+        tree: parsed module
+        file_path: source file path
+    Returns:
+        whether `__all__` is required
+    """
+    return not _is_pure_package_marker(tree, file_path)
+
+
+def _requires_future_annotations(tree: ast.Module) -> bool:
+    """Check whether a module should import future annotations.
+
+    Arguments:
+        tree: parsed module
+    Returns:
+        whether `from __future__ import annotations` is required
+    """
+    for node in tree.body:
+        if (
+            isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Constant)
+            and isinstance(node.value.value, str)
+        ):
+            continue
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            continue
+        return True
+    return False
+
+
+def _returns_none(function_node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Check whether a function is annotated as returning `None`.
+
+    Arguments:
+        function_node: function or method definition
+    Returns:
+        whether the return annotation is `None`
+    """
+    returns = function_node.returns
+    if isinstance(returns, ast.Constant) and returns.value is None:
+        return True
+    return isinstance(returns, ast.Name) and returns.id == "None"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- move contributor-facing style guidance out of `AGENTS.md` into `docs/STYLE.md`
- add `docs/ARCHITECTURE.md` for package layout, data flow, dependency boundaries, and operational notes
- add the local `audit-style` skill and helper script for conservative style audits
- update `AGENTS.md` to reference the new docs and the working pytest command for this branch stack

## Validation
- `uv run ruff format skills/audit-style/scripts/audit_style.py`
- `uv run ruff check --fix skills/audit-style/scripts/audit_style.py`
- `uv run ty check skills/audit-style/scripts/audit_style.py`
